### PR TITLE
Fixes applied to this update:

### DIFF
--- a/src/bri.f90
+++ b/src/bri.f90
@@ -11,6 +11,7 @@ subroutine  BRI (T1,MONCE,PSIHNEW,YCOUNT,ZTEN)
   real :: ANEW, BNEW, CNEW, DNEW
   real :: Pot_S, WG1, CR1, TDIF, RADCOR, TSURF, USTAR1
   real :: ZtenOVERL, ZOVERL, PSImzten, PSIMNEW, X1
+  integer :: icnt
 
 
 ! Code altered 5th May 1992 ... transfer from Vel.for.
@@ -32,6 +33,7 @@ subroutine  BRI (T1,MONCE,PSIHNEW,YCOUNT,ZTEN)
   X1 = 0
 
   IF (YCOUNT <= 0 .and. IFIRST == 0) THEN
+    ! Nighttime setup (YCOUNT <= 0)
 
 !       MOL = 10E5
     TSTAR = 0
@@ -43,7 +45,7 @@ subroutine  BRI (T1,MONCE,PSIHNEW,YCOUNT,ZTEN)
        
 ! Start the surface temp at some nominal value.
        
-    write(*,*) 'in the second branch'
+    ! Daytime setup (YCOUNT >= 1)
     otemp = atemp
     T1 = ATEMP - 1
     TSTAR = 0
@@ -54,8 +56,6 @@ subroutine  BRI (T1,MONCE,PSIHNEW,YCOUNT,ZTEN)
       QN(I) = q_fine(i)
     end do
     IFIRST = 2
-    write(*,*) otemp, t1, tstar, t, u, v, qn
-
   end if
 
 !     Surface Potential Temperature
@@ -68,7 +68,11 @@ subroutine  BRI (T1,MONCE,PSIHNEW,YCOUNT,ZTEN)
   WG1 = SQRT( UG(1)**2 + VG(1)**2 )
   CR1 = ( EXP( -0.2129 * WG1 ) * 0.5542 ) + 0.2
 
-  do while (.not. (eq(xmod,0.0)))
+
+  ! **  Mitre the night-time loop; cycle through twice (120s).
+  icnt = 2
+  do while ( icnt > 0 )
+    icnt = icnt - 1
     
     TDIF = ABS( T(1) - Pot_S )
   
@@ -176,11 +180,6 @@ subroutine  BRI (T1,MONCE,PSIHNEW,YCOUNT,ZTEN)
     T1 = ( T1 + T2 )/ 2.0
     T1 = T1 - 0.017
   
-  
-  ! **  Mitre the night-time loop; cycle through twice (120s).
-  
-    X1 = X1 + 1
-    XMOD = MOD ( X1 , 2.0 )
   end do
 
 ! **  Call MOM to calculate the night-time vertical profiles of

--- a/src/calc.f90
+++ b/src/calc.f90
@@ -49,12 +49,12 @@ end
  
 real pure function dectim(t)
   implicit none
-! Converts time (HrMinSec Format) to decimal
+! Converts time formatted as "HHMM" (2-digit hours and 2-digit minutes) to decimal seconds
   real, intent(in) :: t
   real :: hour, minute
 
   minute = modulo(t,100.0)
   hour = (t - minute)/100.0
 
-  dectim = hour + (minute/60.0)
+  dectim = ( hour + (minute/60.0) ) * 3600
 end function dectim

--- a/src/config_gen.f90
+++ b/src/config_gen.f90
@@ -5,7 +5,7 @@ program sim_input_gen
 
   type(json_core) :: json
   type(json_value), pointer :: p, inp, met, soil, veg, wind, time
-  type(json_value), pointer :: temp_snd, humid_snd
+  type(json_value), pointer :: temp_snd, wind_snd
 
   ! initialize the class
   call json%initialize(compact_reals=.true., real_format='*')
@@ -97,12 +97,12 @@ program sim_input_gen
   call json%add(temp_snd, 'ts', [24,24,23,24,11,9,4,2,2,-7,-10,-40])
   call json%add(temp_snd, 'dep', [5,5,3,8,7,11,6,7,15,17,30,30])
 
-  ! Humidity sounding
-  call json%create_object(humid_snd, 'humidity_sounding')
-  call json%add(inp, humid_snd)
-  call json%add(humid_snd, 'dd0', [180,225,240,225,215,230,240,245,255,195])
-  call json%add(humid_snd, 'ff0', [7,10,35,25,15,15,30,25,44,43,14])
-  call json%add(humid_snd, 'zh', [0,1,3,5,7,9,14,20,30,41,54])
+  ! Wind sounding
+  call json%create_object(wind_snd, 'wind_sounding')
+  call json%add(inp, wind_snd)
+  call json%add(wind_snd, 'dd0', [180,185,225,240,225,215,230,240,245,255,195])
+  call json%add(wind_snd, 'ff0', [7,10,35,25,15,15,30,25,44,43,14])
+  call json%add(wind_snd, 'zh', [0,1,3,5,7,9,14,20,30,41,54])
   nullify(inp)  !don't need this anymore
 
   ! write the file:

--- a/src/config_mod.f90
+++ b/src/config_mod.f90
@@ -5,7 +5,7 @@ module config_mod
 
   private
   public :: load_config
-  public :: t_met, t_veg, t_wind, t_soil, t_temp, t_humid, t_timeloc
+  public :: t_met, t_veg, t_wind, t_soil, t_temp, t_windsnd, t_timeloc
 
 ! config_mod provides data structures and subroutines to read data from the 
 ! model configuration file and initialize variables to default values.  Data 
@@ -17,9 +17,9 @@ module config_mod
 !  t_timeloc: Time and Location
 !  t_veg: Vegetation
 !  t_soil: Soil
-!  t_wind: Wind speed and direction
+!  t_wind: Geostrophic wind components
 !  t_temp: Temperature sounding
-!  t_humid: Humidity sounding
+!  t_windsnd: Wind sounding
 
   type t_met
     real(kind=real64) :: omega, zo, obst_hgt
@@ -58,11 +58,11 @@ module config_mod
     real(kind=real64), dimension(:), allocatable :: ps, ts, dep
   end type t_temp
 
-  type t_humid
+  type t_windsnd
     real(kind=real64), dimension(:), allocatable :: dd0, ff0, zh
     real(kind=real64) :: thick
     integer :: num_obs
-  end type t_humid
+  end type t_windsnd
 
 contains
 
@@ -88,7 +88,7 @@ contains
     return
   end subroutine destroy_json 
 
-  subroutine load_config(file, met, timeloc, veg, wind, soil, temp, humidity)
+  subroutine load_config(file, met, timeloc, veg, wind, soil, temp, windsnd)
     type(json_file) :: json
     type(t_met) :: met
     type(t_timeloc) :: timeloc
@@ -96,7 +96,7 @@ contains
     type(t_wind) :: wind
     type(t_soil) :: soil
     type(t_temp) :: temp
-    type(t_humid) :: humidity
+    type(t_windsnd) :: windsnd
     logical :: found, namelist_style
     integer :: error_cnt
 
@@ -116,7 +116,7 @@ contains
     found = .false.
     namelist_style = .true.
 
-    ! Load data structures: met, veg, wind, soil, temp_snd, humid_snd
+    ! Load data structures: met, veg, wind, soil, temp_snd, wind_snd
 
     ! Meteorological
     path = '.meteorological'
@@ -242,15 +242,15 @@ contains
     call json%get(root//path//'.dep',temp%dep, found)
     if (.not. found) stop 1
   
-    ! Humidity
-    path = '.humidity_sounding'
-    call json%get(root//path//'.dd0', humidity%dd0, found)
+    ! Wind
+    path = '.wind_sounding'
+    call json%get(root//path//'.dd0', windsnd%dd0, found)
     if (.not. found) stop 1
-    call json%get(root//path//'.ff0', humidity%ff0, found)
+    call json%get(root//path//'.ff0', windsnd%ff0, found)
     if (.not. found) stop 1
-    call json%get(root//path//'.zh', humidity%zh, found)
+    call json%get(root//path//'.zh', windsnd%zh, found)
     if (.not. found) stop 1
-    call json%get(root//'.nobs_ptq', humidity%num_obs, found)
+    call json%get(root//'.nobs_ptq', windsnd%num_obs, found)
     if (.not. found) stop 1
 
     ! Clean up

--- a/src/constants_mod.f90
+++ b/src/constants_mod.f90
@@ -3,7 +3,7 @@ module constants
   private
   public :: vert_spacing, rhow, DELTA, rot_rate_earth, siga, dens, ft, ZA, SIGMA
   public :: LE, KARMAN, GRAV, R, RAD, CP, radian, sdec, Kts_To_Metres
-  public :: Ft_To_Metres, Degs_To_Radians, Celsius_To_Kelvin
+  public :: Ft_To_Metres, Degs_To_Radians, Celsius_to_Kelvin
   public :: f_soil_lut, f_veg_lut, f_precip_lut
 
   integer, parameter :: vert_spacing = 250

--- a/src/daykm.f90
+++ b/src/daykm.f90
@@ -9,6 +9,7 @@ subroutine  DAYKM(thick)
 
   real :: KTOP , KMA , KMAPRI , KMW(50)
   real, intent(inout) :: THICK
+  real :: RATIO, SIGN
 
   integer :: I, J, L, M
 
@@ -26,7 +27,15 @@ subroutine  DAYKM(thick)
 ! **  using the standard flux profile law.  Calculate the derivative
 ! **  of KMA and define K at the top of the mixing layer to be zero.
 
-    KMA = KARMAN * USTAR * ZA * ( 1.0 - ( 15.0 * ZA / MOL )**0.25)
+    !KMA = KARMAN * USTAR * ZA * ( 1.0 - ( 15.0 * ZA / MOL )**0.25)
+    ! Prevent possible divide-by-zero
+    if( eq(MOL,0.0,1E-4) ) MOL=1E-4
+    ! Deal with negative Monin-Obukhov length values by carrying the sign
+    ! through the exponent
+    RATIO = ABS( 15.0 * ZA / MOL )
+    SIGN = 1.0
+    IF( MOL < 0.0 ) SIGN = -1.0
+    KMA = KARMAN * USTAR * ZA * ( 1.0 - SIGN*RATIO**0.25 )
     KM(1) = KMA
     KMW(1) = KMA
     KMAPRI = KMA * (1.0 / ZA - ( 15.0 / MOL ) / (1.0 - 15.0 * ZA / MOL))

--- a/src/globals.f90
+++ b/src/globals.f90
@@ -49,7 +49,6 @@ module globals
   real :: Y = 1.0
   real :: ALBG = 0.0
   real :: ALBF = 0.0
-  real :: XMOD = 0.0
   real :: SIGF = 0.0
   real :: HG = 0.0
   real :: AHUM = 0.0

--- a/src/loadjson.f90
+++ b/src/loadjson.f90
@@ -1,6 +1,6 @@
 program loadjson
   use simsphere_mod, only: t_met, t_timeloc, t_veg, t_wind, t_soil, t_temp,  &
-                           t_humid, load_config
+                           t_windsnd, load_config
   use, intrinsic :: iso_fortran_env, only: error_unit
 
   type(t_met) :: met
@@ -9,7 +9,7 @@ program loadjson
   type(t_wind) :: wind
   type(t_soil) :: soil
   type(t_temp) :: temp
-  type(t_humid) :: humidity
+  type(t_windsnd) :: windsnd
 
   character(len=:), allocatable :: cfg_file
 
@@ -18,7 +18,7 @@ program loadjson
     cfg_file = 'i_model.json'
   end if
 
-  call load_config(cfg_file, met, timeloc, veg, wind, soil, temp, humidity)
+  call load_config(cfg_file, met, timeloc, veg, wind, soil, temp, windsnd)
   
   deallocate(cfg_file)
 

--- a/src/mom.f90
+++ b/src/mom.f90
@@ -8,12 +8,20 @@ subroutine  MOM (Pot_S,DT,MONCE)
 ! **  surface and mixing layers.
 
 
-  real :: CR(46), OK(46), BX(46), WIND(46), WGEOS(46)
+! ** Arguments passed in
+  real :: Pot_S
+  integer :: DT, MONCE
+
+! ** Local dynamic variables
+  real :: BX(46), WIND(46), WGEOS(46)
   real :: B(46), DUW(46), KRAD, DVW(46), DTW(46), RI(46)
-  real :: DZ, SB, Pot_S, UIF, UIF2, RC, BX1
   real :: DU, DV, ABDU, ABDV, X1, OKMAX
-  integer :: IMAX, IMAX1, DT, MONCE
-  integer :: I
+  integer :: I, icnt
+
+! ** Local static variables saved between calls
+  real, save :: CR(46), OK(46)
+  real, save :: DZ, SB, UIF, UIF2, RC, BX1
+  integer, save :: IMAX, IMAX1
 
 !      INCLUDE 'modvars.h'
 
@@ -62,9 +70,12 @@ subroutine  MOM (Pot_S,DT,MONCE)
 ! **  Calculate bulk parameters .... Windspeed, Geostrophic Windspeed
 ! **  and Critical Richardson number at all levels.
 
-!    do while (.not. eq(xmod,0.0))
-  100 do I = 1 , IMAX
-!      do I = 1 , IMAX
+  ! **  Cycle through twice (120s).
+  icnt = 2
+  do while ( icnt > 0 )
+    icnt = icnt - 1
+
+      do I = 1 , IMAX
         WIND(I) = SQRT( U(I)**2 + V(I)**2 )
         WGEOS(I) = SQRT( UG(I)**2 + VG(I)**2 )
         CR(I) = ( EXP( -0.2129 * WGEOS(I) ) * 0.5542 ) + 0.2
@@ -135,12 +146,7 @@ subroutine  MOM (Pot_S,DT,MONCE)
   
     QD(1) = QN(1)
   
-  ! **  Increment the time control and cycle through twice (120s).
-  
-    X1 = X1 + 1
-    XMOD = MOD ( X1 , 2.0 )
-!  end do
-  IF (.not. eq(XMOD,0.0)) GO TO 100
+  end do
 
   AWIND =  ( SQRT(U(1)**2 + V(1)**2) )
 

--- a/src/netrad.f90
+++ b/src/netrad.f90
@@ -92,11 +92,10 @@ subroutine  NETRAD (Time,BareRadioTemp,VegnRadioTemp,BareNetRadn,VegnNetRadn,Mix
 End
 
 Subroutine  Lwdown
-  use simsphere_mod, only: aepsi, sigma, t_fine, tdif_s
+  use simsphere_mod, only: Lwdn, aepsi, sigma, t_fine, tdif_s
   implicit none
 
 !      INCLUDE 'modvars.h'
-  real :: Lwdn
 
   Lwdn = aepsi*sigma*(T_fine(3) - Tdif_s - 1.5)**4
 

--- a/src/output.f90
+++ b/src/output.f90
@@ -34,8 +34,8 @@ contains
     If (Bowen < 0.0) Bowen = undefined
   
     If (.not. eq(FRVEG,0.0)) then
-      air_leaf_T = TAF - 273.23
-  !ground_T = TG - 273.23
+      air_leaf_T = TAF - Celsius_to_Kelvin
+  !ground_T = TG - Celsius_to_Kelvin
     else
       air_leaf_T = undefined
   !ground_T = undefined
@@ -66,10 +66,10 @@ contains
       call json%add(out,'Sensible Heat Flux/Wm-2',real(heat,real64))
       call json%add(out,'Latent Heat Flux/Wm-2',real(evap,real64))
       call json%add(out,'Ground Flux/Wm-2',real(g_flux,real64))
-      call json%add(out,'Air Temperature 50m/C',real(atemp-273.23,real64))
-      call json%add(out,'Air Temperature 10m/C',real(ta-273.23,real64))
+      call json%add(out,'Air Temperature 50m/C',real(atemp-Celsius_to_Kelvin,real64))
+      call json%add(out,'Air Temperature 10m/C',real(ta-Celsius_to_Kelvin,real64))
       call json%add(out,'Air Temperature Foliage/C',real(air_leaf_t,real64))
-      call json%add(out,'Radiometric Temperature/C',real(otemp-273.23,real64))
+      call json%add(out,'Radiometric Temperature/C',real(otemp-Celsius_to_Kelvin,real64))
       call json%add(out,'Wind 50m/kts',real(awind*1.98,real64))
       call json%add(out,'Wind 10m/kts',real(uten*1.98,real64))
       call json%add(out,'Wind in foliage/kts',real(uaf*1.98,real64))
@@ -102,10 +102,10 @@ contains
         call json%add(out,'Sensible Heat Flux/Wm-2',real(heat,real64))
         call json%add(out,'Latent Heat Flux/Wm-2',real(evap,real64))
         call json%add(out,'Ground Flux/Wm-2',real(g_flux,real64))
-        call json%add(out,'Air Temperature 50m/C',real(atemp-273.23,real64))
-        call json%add(out,'Air Temperature 10m/C',real(ta-273.23,real64))
+        call json%add(out,'Air Temperature 50m/C',real(atemp-Celsius_to_Kelvin,real64))
+        call json%add(out,'Air Temperature 10m/C',real(ta-Celsius_to_Kelvin,real64))
         call json%add(out,'Air Temperature Foliage/C',real(air_leaf_t,real64))
-        call json%add(out,'Radiometric Temperature/C',real(otemp-273.23,real64))
+        call json%add(out,'Radiometric Temperature/C',real(otemp-Celsius_to_Kelvin,real64))
         call json%add(out,'Wind 50m/kts',real(awind*1.98,real64))
         call json%add(out,'Wind 10m/kts',real(uten*1.98,real64))
         call json%add(out,'Wind in foliage/kts',real(uaf*1.98,real64))
@@ -135,10 +135,10 @@ contains
         call json%add(out,'Sensible Heat Flux/Wm-2',real(heat,real64))
         call json%add(out,'Latent Heat Flux/Wm-2',real(evap,real64))
         call json%add(out,'Ground Flux/Wm-2',real(g_flux,real64))
-        call json%add(out,'Air Temperature 50m/C',real(atemp-273.23,real64))
-        call json%add(out,'Air Temperature 10m/C',real(ta-273.23,real64))
+        call json%add(out,'Air Temperature 50m/C',real(atemp-Celsius_to_Kelvin,real64))
+        call json%add(out,'Air Temperature 10m/C',real(ta-Celsius_to_Kelvin,real64))
         call json%add(out,'Air Temperature Foliage/C',real(air_leaf_t,real64))
-        call json%add(out,'Radiometric Temperature/C',real(otemp-273.23,real64))
+        call json%add(out,'Radiometric Temperature/C',real(otemp-Celsius_to_Kelvin,real64))
         call json%add(out,'Wind 50m/kts',real(awind*1.98,real64))
         call json%add(out,'Wind 10m/kts',real(uten*1.98,real64))
         call json%add(out,'Wind in foliage/kts',real(uaf*1.98,real64))

--- a/src/simsphere_mod.f90
+++ b/src/simsphere_mod.f90
@@ -1,6 +1,6 @@
 module simsphere_mod
   use config_mod, only: t_met, t_timeloc, t_veg, t_wind, t_soil, t_temp,    &
-                        t_humid, load_config
+                        t_windsnd, load_config
   use constants
   use globals
   use snding_mod, only: splint, spline
@@ -93,8 +93,8 @@ module simsphere_mod
       If (Bowen < 0.0) Bowen = undefined
     
       If (.not. eq(FRVEG,0.0)) then
-        air_leaf_T = TAF - 273.23
-    !ground_T = TG - 273.23
+        air_leaf_T = TAF - Celsius_to_Kelvin
+    !ground_T = TG - Celsius_to_Kelvin
       else
         air_leaf_T = undefined
     !ground_T = undefined
@@ -125,10 +125,10 @@ module simsphere_mod
         call json%add(out,'Sensible Heat Flux/Wm-2',real(heat,real64))
         call json%add(out,'Latent Heat Flux/Wm-2',real(evap,real64))
         call json%add(out,'Ground Flux/Wm-2',real(g_flux,real64))
-        call json%add(out,'Air Temperature 50m/C',real(atemp-273.23,real64))
-        call json%add(out,'Air Temperature 10m/C',real(ta-273.23,real64))
+        call json%add(out,'Air Temperature 50m/C',real(atemp-Celsius_to_Kelvin,real64))
+        call json%add(out,'Air Temperature 10m/C',real(ta-Celsius_to_Kelvin,real64))
         call json%add(out,'Air Temperature Foliage/C',real(air_leaf_t,real64))
-        call json%add(out,'Radiometric Temperature/C',real(otemp-273.23,real64))
+        call json%add(out,'Radiometric Temperature/C',real(otemp-Celsius_to_Kelvin,real64))
         call json%add(out,'Wind 50m/kts',real(awind*1.98,real64))
         call json%add(out,'Wind 10m/kts',real(uten*1.98,real64))
         call json%add(out,'Wind in foliage/kts',real(uaf*1.98,real64))
@@ -161,10 +161,10 @@ module simsphere_mod
           call json%add(out,'Sensible Heat Flux/Wm-2',real(heat,real64))
           call json%add(out,'Latent Heat Flux/Wm-2',real(evap,real64))
           call json%add(out,'Ground Flux/Wm-2',real(g_flux,real64))
-          call json%add(out,'Air Temperature 50m/C',real(atemp-273.23,real64))
-          call json%add(out,'Air Temperature 10m/C',real(ta-273.23,real64))
+          call json%add(out,'Air Temperature 50m/C',real(atemp-Celsius_to_Kelvin,real64))
+          call json%add(out,'Air Temperature 10m/C',real(ta-Celsius_to_Kelvin,real64))
           call json%add(out,'Air Temperature Foliage/C',real(air_leaf_t,real64))
-          call json%add(out,'Radiometric Temperature/C',real(otemp-273.23,real64))
+          call json%add(out,'Radiometric Temperature/C',real(otemp-Celsius_to_Kelvin,real64))
           call json%add(out,'Wind 50m/kts',real(awind*1.98,real64))
           call json%add(out,'Wind 10m/kts',real(uten*1.98,real64))
           call json%add(out,'Wind in foliage/kts',real(uaf*1.98,real64))
@@ -194,10 +194,10 @@ module simsphere_mod
           call json%add(out,'Sensible Heat Flux/Wm-2',real(heat,real64))
           call json%add(out,'Latent Heat Flux/Wm-2',real(evap,real64))
           call json%add(out,'Ground Flux/Wm-2',real(g_flux,real64))
-          call json%add(out,'Air Temperature 50m/C',real(atemp-273.23,real64))
-          call json%add(out,'Air Temperature 10m/C',real(ta-273.23,real64))
+          call json%add(out,'Air Temperature 50m/C',real(atemp-Celsius_to_Kelvin,real64))
+          call json%add(out,'Air Temperature 10m/C',real(ta-Celsius_to_Kelvin,real64))
           call json%add(out,'Air Temperature Foliage/C',real(air_leaf_t,real64))
-          call json%add(out,'Radiometric Temperature/C',real(otemp-273.23,real64))
+          call json%add(out,'Radiometric Temperature/C',real(otemp-Celsius_to_Kelvin,real64))
           call json%add(out,'Wind 50m/kts',real(awind*1.98,real64))
           call json%add(out,'Wind 10m/kts',real(uten*1.98,real64))
           call json%add(out,'Wind in foliage/kts',real(uaf*1.98,real64))

--- a/src/snding.f90
+++ b/src/snding.f90
@@ -1,4 +1,4 @@
-SUBROUTINE SNDING (ZLS, Old_Ahum, temp, humidity, timeloc, wind)
+SUBROUTINE SNDING (ZLS, Old_Ahum, temp, windsnd, timeloc, wind)
   use simsphere_mod
   implicit none
 
@@ -7,7 +7,7 @@ SUBROUTINE SNDING (ZLS, Old_Ahum, temp, humidity, timeloc, wind)
 
   type(t_timeloc) :: timeloc
   type(t_temp) :: temp
-  type(t_humid) :: humidity
+  type(t_windsnd) :: windsnd
   type(t_wind) :: wind
   real :: EW(50),QS(50), ZLS(50)
   real :: UCOMP(50), VCOMP(50), GMQ(50), Pot_Temp (50)
@@ -33,10 +33,10 @@ SUBROUTINE SNDING (ZLS, Old_Ahum, temp, humidity, timeloc, wind)
 ! Temporary until subroutine calls, globals reworked
   station_height = timeloc%station_height
   nobs_wind = wind%num_obs
-  nobs_ptq = humidity%num_obs
-  dd0 = humidity%dd0
-  ff0 = humidity%ff0
-  zh = humidity%zh
+  nobs_ptq = windsnd%num_obs
+  dd0 = windsnd%dd0
+  ff0 = windsnd%ff0
+  zh = windsnd%zh
   ps = temp%ps
   ts = temp%ts
   dep = temp%dep
@@ -61,7 +61,9 @@ SUBROUTINE SNDING (ZLS, Old_Ahum, temp, humidity, timeloc, wind)
 
       TBAR = (( TS(I) + TS(I+1) ) / 2 ) + Celsius_to_Kelvin ! Average Temperature (K)
       THICK = 287 * (TBAR / 9.8) * ALOG(PS(I) / PS(I+1)) ! Thickness (m)
-      humidity%thick = thick
+      ! AAP: I don't think THICK needs to be passed on here.  windsnd%thick is
+      ! AAP: used for the mixed layer thickness only.
+      !windsnd%thick = thick
       HEIGHT = HEIGHT + THICK ! Height (above station) of pressure level
       ZLS(I+1) = HEIGHT
       GM(I) = ( Pot_Temp(I+1) - Pot_Temp(I) ) / THICK ! d(Theta)/dZ
@@ -209,9 +211,9 @@ SUBROUTINE SNDING (ZLS, Old_Ahum, temp, humidity, timeloc, wind)
 ! Calc lapse rate of temp in 1st layer and EW at screen level for
 ! use in the calc of screen level sat'n spec humidity.
 
-  ATEMP = 50 * (TS(2) - TS(1)) / ZLS(2) + TS(1) + 273.15
-  TSCREN = TS(1) + 273.15 ! Screen Temperature
-  EW = 6.11 * EXP (( 2.49E6 / 461.51 ) *(1 / 273.15 - 1 / TSCREN))
+  ATEMP = 50 * (TS(2) - TS(1)) / ZLS(2) + TS(1) + Celsius_to_Kelvin
+  TSCREN = TS(1) + Celsius_to_Kelvin ! Screen Temperature
+  EW = 6.11 * EXP (( 2.49E6 / 461.51 ) *(1 / Celsius_to_Kelvin - 1 / TSCREN))
 
   OSHUM = 0.622 * EW(1) / PS(1)
   AHUM = QS(1)
@@ -227,7 +229,7 @@ SUBROUTINE SNDING (ZLS, Old_Ahum, temp, humidity, timeloc, wind)
   Tdif_50 = Pot_50 - Atemp
   Tdif_s = Tdif_50 - 0.5
 
-!        tdeww = tdew-273.15
+!        tdeww = tdew-Celsius_to_Kelvin
 !        expt=7.5*tdeww/(237.3+tdeww)
 !        eww = 6.11*10**expt
 !        ewww = qs(j)*ps(j)/(0.378*qs(j)+0.622)

--- a/src/start.f90
+++ b/src/start.f90
@@ -1,4 +1,4 @@
-subroutine  START (Obst_Hgt, dual_regime, zo_patch, temp, humidity, timeloc, wind)
+subroutine  START (Obst_Hgt, dual_regime, zo_patch, temp, windsnd, timeloc, wind)
   use simsphere_mod
   implicit none
 
@@ -19,7 +19,7 @@ subroutine  START (Obst_Hgt, dual_regime, zo_patch, temp, humidity, timeloc, win
   type(t_wind) :: wind
   type(t_soil) :: soil
   type(t_temp) :: temp
-  type(t_humid) :: humidity
+  type(t_windsnd) :: windsnd
 
   character(len=:), allocatable :: cfg_file
 
@@ -28,7 +28,7 @@ subroutine  START (Obst_Hgt, dual_regime, zo_patch, temp, humidity, timeloc, win
     cfg_file = 'i_model.json'
   end if
 
-  call load_config(cfg_file, met, timeloc, veg, wind, soil, temp, humidity)
+  call load_config(cfg_file, met, timeloc, veg, wind, soil, temp, windsnd)
 
   deallocate(cfg_file)
 
@@ -125,8 +125,8 @@ subroutine  START (Obst_Hgt, dual_regime, zo_patch, temp, humidity, timeloc, win
 
     close (unit = 1)
 
-    mintemp = mintemp + 273
-    maxtemp = maxtemp + 273
+    mintemp = mintemp + Celsius_to_Kelvin
+    maxtemp = maxtemp + Celsius_to_Kelvin
 
   end if
 

--- a/tests/test_bri.f90
+++ b/tests/test_bri.f90
@@ -1,7 +1,7 @@
 program test_bri
   use simsphere_mod, only: ifirst, tstar, t, u, v, qn, otemp, atemp, tdif_s, & 
                            ug, vg, tdif_50, zo, awind, ustar, heat, bulk,    &
-                           uten, mol, advgt, xmod, evap, qd, u_fine, v_fine, &
+                           uten, mol, advgt, evap, qd, u_fine, v_fine, &
                            t_fine, q_fine, qd, qn, cf, aptemp, eq
   use mod_testing, only: assert, initialize_tests, report_tests
   implicit none
@@ -136,7 +136,6 @@ contains
     mol = 0.0
     tstar = 1.0
     uten = 1.0
-    xmod = 1.0
     u = 1.0
     v = 2.0
     do i = 1,size(t)

--- a/tests/test_calc.f90
+++ b/tests/test_calc.f90
@@ -27,11 +27,11 @@ program test_calc
   real, parameter :: xlat_exp = 39.25
   real, parameter :: xlong_exp = 53.0
   real, parameter :: cf_exp = 9.19953891E-05
-  real, parameter :: timend_exp = 23.5
-  real, parameter :: strtim_exp = 5.5
+  real, parameter :: timend_exp = 23.5*3600
+  real, parameter :: strtim_exp = 5.5*3600
   real, parameter :: arg1_exp = 20.0
   real, parameter :: t_1_exp = 20.5
-  real, parameter :: dectim_exp = 22.75 ! 22:45
+  real, parameter :: dectim_exp = 22.75*3600 ! 22:45
   integer, parameter :: arg2_exp = 37
 
   n = 1

--- a/tests/test_load_data.f90
+++ b/tests/test_load_data.f90
@@ -1,5 +1,5 @@
 program test_load_data
-  use simsphere_mod, only: t_met, t_wind, t_soil, t_veg, t_temp, t_humid,   &
+  use simsphere_mod, only: t_met, t_wind, t_soil, t_veg, t_temp, t_windsnd,   &
                            t_timeloc, load_config, eq
   use mod_testing, only: assert, initialize_tests, report_tests
   use iso_fortran_env, only: real32, real64
@@ -11,7 +11,7 @@ program test_load_data
   type(t_soil) :: soil
   type(t_veg) :: veg
   type(t_temp) :: temp
-  type(t_humid) :: humidity
+  type(t_windsnd) :: windsnd
   character(len=:), allocatable :: cfg_file
 
   logical, dimension(:), allocatable :: tests
@@ -29,11 +29,11 @@ program test_load_data
   cfg_file = 'i_model.json'
 
   ! Initialize data structures
-  call load_config(cfg_file, met, timeloc, veg, wind, soil, temp, humidity)
+  call load_config(cfg_file, met, timeloc, veg, wind, soil, temp, windsnd)
 
   tests(n) = assert(wind%num_obs == 11, 'nobs_wind == 11')
   n = n + 1
-  tests(n) = assert(humidity%num_obs == 12, 'nobs_ptq == 12')
+  tests(n) = assert(windsnd%num_obs == 12, 'nobs_ptq == 12')
   n = n + 1
   tests(n) = assert(eq(met%omega,3.13_real64), 'omega == 3.13')
   n = n + 1

--- a/tests/test_snding.f90
+++ b/tests/test_snding.f90
@@ -2,7 +2,7 @@ program test_snding
   use simsphere_mod, only: deltaz, gm, ntrp, atemp, tdif_s, aptemp, zi,      &
                            tscren, oshum, ahum, ps1, o_pot_tmp, tdif_50, ugs,&
                            vgs, t_met, t_wind, t_soil, t_veg, t_temp,        &
-                           t_humid, t_timeloc, load_config, eq 
+                           t_windsnd, t_timeloc, load_config, eq 
   use mod_testing, only: assert, initialize_tests, report_tests
   implicit none
 
@@ -12,7 +12,7 @@ program test_snding
   type(t_soil) :: soil
   type(t_veg) :: veg
   type(t_temp) :: temp
-  type(t_humid) :: humidity
+  type(t_windsnd) :: windsnd
   character(len=:), allocatable :: cfg_file
 
   logical, dimension(:), allocatable :: tests
@@ -50,13 +50,13 @@ program test_snding
   ! Initialize JSON, data structures
   cfg_file = 'i_model.json'
 
-  call load_config(cfg_file, met, timeloc, veg, wind, soil, temp, humidity)
+  call load_config(cfg_file, met, timeloc, veg, wind, soil, temp, windsnd)
 
   ! Initialize
 !  call start
 
   call snding_init
-  call snding(arg1,arg2, temp, humidity, timeloc, wind)
+  call snding(arg1,arg2, temp, windsnd, timeloc, wind)
 
   tests(n) = assert(eq(atemp,atemp_exp), 'atemp')
   n = n + 1


### PR DESCRIPTION
- Fixed 2-cycle loops in bri.f90 and mom.f90.
- Fixed routien dectim in calc.f90 to return decimal time in seconds.
- Fixed misnamed humidity variable name to windsnd (wind sounding) in:
     config_gen.f90
     config_mod.f90
     loadjson.f90
     main.f90
     simsphere_mod.f90
     snding.f90
     start.f90
     test_load_data.f90
     test_snding.f90
- Updated variable name Celsius_To_Kelvin in constants_mod.f90 to name
     Celsius_to_Kelvin to be consistent with the other code portions.
- Fixed use of variable MOL in daykm.f90 to allow for exponent of negative numbers.
- Removed unused variable XMOD from globals.f90.
- Fixed time variables in main.f90 to use values of seconds.
- Removed (commented-out) met, veg and soil variables from main.f90 since they are not referenced.
- Added "SAVE" characteristic to local variables in mom.f90 that are initialized and reused upon reentry.
- Fixed routine Lwdown to use global variable Lwdn instead of defining a local variable.
- Replace all occurences of 273.15 or 273.23 with the variable Celsius_to_Kelvin.
- Disabled the saving of the variable "thick" in snding.f90 due to apparent mis-use.
- Added missing second wind direction level to wind sounding for default input data.
- Removed unused variable xmod from test_bri.f90.
- Adjusted tests in test_calc.f90 to accomodate times in seconds.